### PR TITLE
omit the field from the JSON output if the pointer is nil

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ type SendRequest struct {
 }
 type UpdateScheduleRequest struct {
 	NotificationId    string                 `json:"notificationId,omitempty"`
-	User              User                   `json:"user,omitempty"`
+	User              *User                   `json:"user,omitempty"`
 	MergeTags         map[string]interface{} `json:"mergeTags,omitempty"`
 	Replace           map[string]string      `json:"replace,omitempty"`
 	ForceChannels     []string               `json:"forceChannels,omitempty"`

--- a/main_schedual_update_test.go
+++ b/main_schedual_update_test.go
@@ -11,11 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type ExpectedUpdateScheduleRequestJsonData struct {
+	NotificationId string `json:"notificationId"`
+	Schedule       string `json:"schedule"`
+}
+
 func TestUpdateSchedulePassesWith202(t *testing.T) {
 	Init(client_id, client_secret)
 	TrackingId := "TrackingId"
 	UpdateScheduleRequest := UpdateScheduleRequest{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"}
-	jsonData, _ := json.Marshal(UpdateScheduleRequest)
+	jsonData, _ := json.Marshal(ExpectedUpdateScheduleRequestJsonData{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"})
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -48,7 +53,7 @@ func TestUpdateScheduleFailsWith500(t *testing.T) {
 	Init(client_id, client_secret)
 	TrackingId := "TrackingId"
 	UpdateScheduleRequest := UpdateScheduleRequest{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"}
-	jsonData, _ := json.Marshal(UpdateScheduleRequest)
+	jsonData, _ := json.Marshal(ExpectedUpdateScheduleRequestJsonData{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"})
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -74,7 +79,7 @@ func TestUpdateSchedulePasses(t *testing.T) {
 	Init(client_id, client_secret)
 	TrackingId := "TrackingId"
 	UpdateScheduleRequest := UpdateScheduleRequest{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"}
-	jsonData, _ := json.Marshal(UpdateScheduleRequest)
+	jsonData, _ := json.Marshal(ExpectedUpdateScheduleRequestJsonData{NotificationId: "baaz", Schedule: "2024-02-20T14:38:03.509Z"})
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 


### PR DESCRIPTION
Changing the field to a pointer type, like User *User, and using `omitempty` tells the JSON serializer to omit the field from the JSON output if the pointer is `nil`
In other words, instead of having this in the API request: `data: {"user":{},"schedule":"2024-03-12T23:05:12.797Z"}` you would have `data: {"schedule":"2024-03-12T23:05:12.797Z"}`